### PR TITLE
Fix GraphQL and Amplify integration

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -1,4 +1,4 @@
-import { type ClientSchema, a, defineData } from "@aws-amplify/backend";
+import { type ClientSchema, a, defineData } from '@aws-amplify/backend';
 
 /*== STEP 1 ===============================================================
 The section below creates a Todo database table with a "content" field. Try
@@ -11,7 +11,7 @@ const schema = a.schema({
     .model({
       content: a.string(),
     })
-    .authorization((allow) => [allow.publicApiKey()]),
+    .authorization((allow) => [allow.owner()]),
 });
 
 export type Schema = ClientSchema<typeof schema>;
@@ -19,7 +19,7 @@ export type Schema = ClientSchema<typeof schema>;
 export const data = defineData({
   schema,
   authorizationModes: {
-    defaultAuthorizationMode: "apiKey",
+    defaultAuthorizationMode: 'userPool',
     apiKeyAuthorizationMode: {
       expiresInDays: 30,
     },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -37,7 +37,7 @@ export default function App() {
     <Authenticator>
       {({ signOut, user }) => (
         <main>
-          <h1>My todos</h1>
+          <h1>{user?.signInDetails?.loginId}'s todos</h1>
           <button onClick={createTodo}>+ new</button>
           <ul>
             {todos.map((todo) => (


### PR DESCRIPTION
Fixes #2

This pull request fixes the integration between GraphQL and Amplify. It includes the following changes:

- Updated import statement in the backend schema file to use single quotes instead of double quotes.

- Changed the authorization mode in the backend schema file from apiKey to owner.

- Updated the page title in the frontend to include the user's name.

These changes ensure that the GraphQL and Amplify integration works correctly and that the user's name is displayed in the page title.

Please review and merge this pull request. Thank you!